### PR TITLE
Add Forge and Envoyer under "Deployments & Hosting"

### DIFF
--- a/learn.php
+++ b/learn.php
@@ -180,7 +180,22 @@ return [
         'name' => 'Basic session-backed internal APIs',
     ],
     [
-        'name' => 'Deployments',
+        'name' => 'Hosting &amp; Deployments',
+        'children' => [
+            [
+                'name' => 'Laravel Forge',
+                'links' => [
+                    'Laravel Forge Docs' => 'https://forge.helpscoutdocs.com/',
+                    'Laracasts Series' => 'https://laracasts.com/series/learn-laravel-forge/',
+                ],
+            ],
+            [
+                'name' => 'Laravel Envoyer',
+                'links' => [
+                    'Laravel Envoyer Docs' => 'https://envoyer.io/',
+                ],
+            ],
+        ],
     ],
     [
         'name' => 'Monitoring (e.g. Bugsnag)',

--- a/resources/views/learn.blade.php
+++ b/resources/views/learn.blade.php
@@ -18,7 +18,7 @@
             <ul class="temp-learn-list">
                 @foreach ($learn as $item)
                 <li>
-                    <div class="list-title">{{ $item['name'] }}</div>
+                    <div class="list-title">{!! $item['name'] !!}</div>
                     @if (isset($item['links']))
                     {!!
                         collect($item['links'])->map(function ($value, $key) {

--- a/resources/views/learn.blade.php
+++ b/resources/views/learn.blade.php
@@ -47,7 +47,7 @@
                 @endforeach
             </ul>
 
-            <p>That's all, for now. Soon: more and better organized links to places to learn each of these technologies/tools, a more robust list of techhnologies, etc., and then later maybe exercises to test them and prove out your learning.</p>
+            <p>That's all, for now. Soon: more and better organized links to places to learn each of these technologies/tools, a more robust list of technologies, etc., and then later maybe exercises to test them and prove out your learning.</p>
         </div>
     </div>
 </div>


### PR DESCRIPTION
In this PR, I added links for Forge & Envoyer under "Deployments & Hosting", fixed a typo, and made it so `&amp;` and other HTML entities aren't escaped in item titles.