### PR TITLE
Making content translatable on learning page and translating it to sp…

### DIFF
--- a/learn.es.php
+++ b/learn.es.php
@@ -115,8 +115,8 @@ return [
                 'name' => 'Sintaxis de Blade &amp; Herencia',
                 'links' => [
                     'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/blade',
-                    'Laracasts Video' => 'https://styde.net/blade-el-sistema-de-plantillas-de-laravel/',
-                    'Laracasts Video' => 'https://styde.net/layouts-con-blade/',
+                    'Video de Styde' => 'https://styde.net/blade-el-sistema-de-plantillas-de-laravel/',
+                    'Video de Styde' => 'https://styde.net/layouts-con-blade/',
                 ],
             ],
             [
@@ -129,21 +129,21 @@ return [
                 'name' => 'Migraciones',
                 'links' => [
                     'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/migrations',
-                    'Laracasts Video' => 'https://styde.net/introduccion-a-las-bases-de-datos-y-migraciones-con-laravel/',
+                    'Video de Styde' => 'https://styde.net/introduccion-a-las-bases-de-datos-y-migraciones-con-laravel/',
                 ],
             ],
             [
                 'name' => 'Sintaxis básica de Eloquent',
                 'links' => [
                     'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/eloquent',
-                    'Laracasts Video' => 'https://styde.net/introduccion-a-eloquent-el-orm-del-framework-laravel/',
+                    'Video de Styde' => 'https://styde.net/introduccion-a-eloquent-el-orm-del-framework-laravel/',
                 ],
             ],
             [
                 'name' => 'CSRF',
                 'links' => [
                     'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/csrf',
-                    'Laracasts Video' => 'https://styde.net/rutas-con-post-y-proteccion-contra-ataques-de-tipo-csrf-en-laravel/',
+                    'Video de Styde' => 'https://styde.net/rutas-con-post-y-proteccion-contra-ataques-de-tipo-csrf-en-laravel/',
                 ],
             ],
             [

--- a/learn.es.php
+++ b/learn.es.php
@@ -1,0 +1,188 @@
+<?php
+
+return [
+    [
+        'name' => 'Comandos de terminal básicos',
+        'links' => [
+            'Video de códigofacilito' => 'https://www.youtube.com/watch?v=FP_4uQXysRU',
+        ],
+    ],
+    [
+        'name' => 'HTML',
+        'links' => [
+            'Refencia de Elementos HTML' => 'https://developer.mozilla.org/es/docs/Web/HTML/Elemento/',
+            'Curso HTML para principiantes de Fazt' => 'https://www.youtube.com/watch?v=rbuYtrNUxg4',
+            'Curso HTML desde cero de EDteam' => 'https://ed.team/cursos/html',
+        ],
+    ],
+    [
+        'name' => 'CSS',
+        'links' => [
+            'Referencia CSS' => 'https://developer.mozilla.org/es/docs/Web/CSS/Referencia_CSS',
+            'Curso CSS para principiantes de Fazt' => 'https://www.youtube.com/watch?v=W6GTDfrWjXs',
+            'Curso CSS desde cero de EDteam' => 'https://ed.team/cursos/css',
+        ],
+    ],
+    [
+        'name' => 'Git',
+        'links' => [
+            'Curso Git de códigofacilito' => 'https://www.youtube.com/watch?v=zH3I1DZNovk&list=PL9xYXqvLX2kMUrXTvDY6GI2hgacfy0rId',
+        ],
+    ],
+    [
+        'name' => 'Ambiente local de PHP',
+        'children' => [
+            [
+                'name' => 'Valet',
+                'links' => [
+                    'Documentación de Laravel' => 'https://docs.laraveles.com/docs/5.5/valet',
+                ],
+            ],
+            [
+                'name' => 'Composer',
+                'links' => [
+                    'Artículo de Styde' => 'https://styde.net/instalacion-de-composer-y-laravel-en-windows/',
+                ],
+            ],
+        ],
+    ],
+    [
+        'name' => 'Comenzando con PHP',
+        'children' => [
+            [
+                'name' => 'Variables',
+                'links' => [
+                    'Manual PHP' => 'https://www.php.net/manual/es/language.variables.php',
+                ],
+            ],
+            [
+                'name' => 'Arreglos',
+                'links' => [
+                    'Manual PHP' => 'https://www.php.net/manual/es/language.types.array.php',
+                ],
+            ],
+            [
+                'name' => 'Funciones',
+                'links' => [
+                    'Manual PHP' => 'https://www.php.net/manual/es/language.functions.php',
+                ],
+            ],
+            [
+                'name' => 'Clases',
+                'links' => [
+                    'Manual PHP' => 'https://www.php.net/manual/es/language.oop5.basic.php',
+                    'Video de Styde' => 'https://styde.net/por-que-necesitamos-clases-y-objetos-php/',
+                ],
+            ],
+            [
+                'name' => 'Constructores',
+                'links' => [
+                    'Video de Styde' => 'https://styde.net/encapsulamiento-y-uso-de-getters-y-setters-en-php/',
+                ],                
+            ],
+            [
+                'name' => 'Herencia Básica',
+                'links' => [
+                    'Video de Styde' => 'https://styde.net/herencia-y-abstraccion-con-php/',
+                ],
+            ],
+        ],
+    ],
+    [
+        'name' => 'Programación orientada a objetos',
+    ],
+    [
+        'name' => 'Creando y ejecutando un nuevo proyecto de Laravel',
+        'links' => [
+            'Documentación de Laravel' => 'https://docs.laraveles.com/docs/5.5/installation',
+            'Video de Styde' => 'https://styde.net/instalacion-de-composer-y-laravel/',
+        ],
+    ],
+    [
+        'name' => 'Conceptos básicos de Laravel',
+        'links' => [
+            'Curso de Laravel desde cero de Styde' => 'https://styde.net/laravel-5/',
+        ],
+        'children' => [
+            [
+                'name' => 'Enrutamiento con Laravel &amp; verbos de HTTP (usando funciones anónimas)',
+                'links' => [
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/routing',
+                    'Video de Styde' => 'https://styde.net/rutas-con-laravel/',
+                ],
+            ],
+            [
+                'name' => 'Sintaxis de Blade &amp; Herencia',
+                'links' => [
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/blade',
+                    'Laracasts Video' => 'https://styde.net/blade-el-sistema-de-plantillas-de-laravel/',
+                    'Laracasts Video' => 'https://styde.net/layouts-con-blade/',
+                ],
+            ],
+            [
+                'name' => 'Bases de datos relacionadas',
+                'links' => [
+                    'Khan Academy Article' => 'https://es.khanacademy.org/computing/computer-programming/sql',
+                ],
+            ],
+            [
+                'name' => 'Migraciones',
+                'links' => [
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/migrations',
+                    'Laracasts Video' => 'https://styde.net/introduccion-a-las-bases-de-datos-y-migraciones-con-laravel/',
+                ],
+            ],
+            [
+                'name' => 'Sintaxis básica de Eloquent',
+                'links' => [
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/eloquent',
+                    'Laracasts Video' => 'https://styde.net/introduccion-a-eloquent-el-orm-del-framework-laravel/',
+                ],
+            ],
+            [
+                'name' => 'CSRF',
+                'links' => [
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/csrf',
+                    'Laracasts Video' => 'https://styde.net/rutas-con-post-y-proteccion-contra-ataques-de-tipo-csrf-en-laravel/',
+                ],
+            ],
+            [
+                'name' => 'Validación',
+                'links' => [
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/validation',
+                ],
+            ],
+            [
+                'name' => 'Envío de correos electrónicos',
+                'links' => [
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/mail',
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/notifications',
+                ],
+            ],
+            [
+                'name' => 'Service Container',
+                'links' => [
+                    'Laravel Docs' => 'https://docs.laraveles.com/docs/5.5/container',
+                ],
+            ],
+        ],
+    ],
+    [
+        'name' => 'JavaScript Básico',
+        'links' => [
+            'Javascript desde cero de EDteam' => 'https://ed.team/cursos/javascript',
+        ],
+    ],
+    [
+        'name' => 'Laravel Mix',
+    ],
+    [
+        'name' => 'Conceptos básicos de APIs internas',
+    ],
+    [
+        'name' => 'Despliegues',
+    ],
+    [
+        'name' => 'Monitoreo (e.g. Bugsnag)',
+    ],
+];

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -1,0 +1,7 @@
+{
+    "Home": "Inicio",
+    "Learn": "Aprende",
+    "Learn Laravel": "Aprende Laravel",
+    "The tech concepts you should know in order to get a job as a Laravel developer.": "Los conceptos técnicos que deberias aprender para obtener un trabajo como un desarrollador de Laravel.",
+    "That's all, for now. Soon: more and better organized links to places to learn each of these technologies/tools, a more robust list of technologies, etc., and then later maybe exercises to test them and prove out your learning.": "Eso es todo por ahora. Pronto: mejores enlaces con mayor organización a lugares donde se podrán aprender cada una de estas tecnologías/herramientas, una lista más robusta de tecnologías, etc. Y, tal vez, más adelante algunos ejercicios o pruebas para probar lo que hayas aprendido."
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -26,8 +26,8 @@
         <nav class="w-full bg-white md:pt-0 px-6 relative z-20 border-t border-b border-gray-light">
             <div class="container mx-auto py-4 max-w-4xl md:flex justify-between items-center text-sm md:text-md md:justify-start">
                 <div class="w-full md:w-1/2 text-center md:text-left flex flex-wrap justify-center items-stretch md:justify-start md:items-start mb-4 md:mb-0">
-                    <a href="/" class="px-2 md:pl-0 md:mr-3 md:pr-3 text-gray-900 no-underline hover:underline md:border-r border-gray-light">Home</a>
-                    <a href="/learn" class="px-2 md:pl-0 md:mr-3 md:pr-3 text-gray-900 no-underline hover:underline">Learn</a>
+                    <a href="/" class="px-2 md:pl-0 md:mr-3 md:pr-3 text-gray-900 no-underline hover:underline md:border-r border-gray-light">{{ __('Home') }}</a>
+                    <a href="/learn" class="px-2 md:pl-0 md:mr-3 md:pr-3 text-gray-900 no-underline hover:underline">{{ __('Learn') }}</a>
                 </div>
                 <div class="w-full md:w-1/2 text-center md:text-right">
 

--- a/resources/views/learn.blade.php
+++ b/resources/views/learn.blade.php
@@ -4,9 +4,12 @@
 <div class="w-full bg-white">
     <!-- title -->
     <div class="text-center px-6 py-12 mb-6 bg-gray-100 border-b">
-        <h1 class=" text-xl md:text-4xl pb-4">Learn Laravel</h1>
+        <h1 class=" text-xl md:text-4xl pb-4">{{ __('Learn Laravel') }}</h1>
         <p class="leading-loose text-gray-dark">
-            The tech concepts you should know in order to get a job as a Laravel developer.
+            {{ __('The tech concepts you should know in order to get a job as a Laravel developer.') }}
+        </p>
+        <p class="text-gray-dark">
+            <a href="/learn" class="no-underline hover:underline">EN</a> | <a href="/learn/es" class="no-underline hover:underline">ES</a>
         </p>
     </div>
     <!-- /title -->
@@ -47,7 +50,7 @@
                 @endforeach
             </ul>
 
-            <p>That's all, for now. Soon: more and better organized links to places to learn each of these technologies/tools, a more robust list of technologies, etc., and then later maybe exercises to test them and prove out your learning.</p>
+            <p>{{ __("That's all, for now. Soon: more and better organized links to places to learn each of these technologies/tools, a more robust list of technologies, etc., and then later maybe exercises to test them and prove out your learning.") }}</p>
         </div>
     </div>
 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,9 +3,17 @@
 
 Route::view('/', 'welcome');
 
-Route::get('learn', function () {
+Route::get('learn/{locale?}', function ($locale = 'en') {
+    App::setLocale($locale);
+
+    if($locale != 'en' && file_exists(base_path("learn.$locale.php"))) {
+        $learnPath = base_path("learn.$locale.php");
+    } else {
+        $learnPath = base_path('learn.php');
+    }
+
     return view('learn', [
-        'learn' => require(base_path('learn.php')),
+        'learn' => require($learnPath),
     ]);
 });
 


### PR DESCRIPTION
I have made the learning page translatable to other languages and added links to Spanish resources. This would contribute to issue #26.

There are packages and other solutions that can make the site translatable, but I went for the simplest option that would maintain the use of the learn.php file to add the resources. 

For the content on the site, I have used the localization feature of Laravel (https://laravel.com/docs/5.8/localization). For the learning PHP file, I edited the route file so we could pass the language as a parameter and choose the localized learn.php file.