### PR TITLE
Add Wordpress to Laravel resource

### DIFF
--- a/learn.en.php
+++ b/learn.en.php
@@ -212,6 +212,12 @@ return [
         ],
     ],
     [
+        'name' => 'Laravel for Wordpress developers',
+        'links' => [
+            'Wordpress to Laravel' => 'https://wptolaravel.com',
+        ],
+    ],
+    [
         'name' => 'Basic JavaScript',
         'links' => [
             'Wes Bos Video Series' => 'https://javascript30.com/',


### PR DESCRIPTION
This PR adds the 'Wordpress to Laravel' resource. which is a video series that explains Laravel to Wordpress developers.
Since Wordpress developers are one of our target groups, I think this PR adds value for that group.