### PR TITLE
Add support for Swedish locale

### DIFF
--- a/app/Localization/Locale.php
+++ b/app/Localization/Locale.php
@@ -7,6 +7,7 @@ class Locale
     protected $locales = [
         'en',
         'es',
+        'sv'
     ];
 
     public function all()

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -5,5 +5,6 @@
     "The tech concepts you should know in order to get a job as a Laravel developer.": "Los conceptos técnicos que deberias aprender para obtener un trabajo como un desarrollador de Laravel.",
     "That's all, for now.": "Eso es todo por ahora.",
     "Soon: more and better organized links to places to learn each of these technologies/tools, a more robust list of technologies, etc., and then later maybe exercises to test them and prove out your learning.": "Pronto: mejores enlaces con mayor organización a lugares donde se podrán aprender cada una de estas tecnologías/herramientas, una lista más robusta de tecnologías, etc. Y, tal vez, más adelante algunos ejercicios o pruebas para probar lo que hayas aprendido.",
-    "Log in": "Entrar"
+    "Log in": "Entrar",
+    "Register": "Registro"
 }

--- a/resources/lang/sv.json
+++ b/resources/lang/sv.json
@@ -1,4 +1,6 @@
 {
+    "Onramp to Laravel": "Påfarten till Laravel",
+    "Providing an easy entrance to Laravel for new developers": "Erbjuder en enkel ingång till Laravel för nya utvecklare",
     "Home": "Hem",
     "Learn": "Träna",
     "Learn Laravel": "Lär dig Laravel",

--- a/resources/lang/sv.json
+++ b/resources/lang/sv.json
@@ -1,0 +1,10 @@
+{
+    "Home": "Hem",
+    "Learn": "Träna",
+    "Learn Laravel": "Lär dig Laravel",
+    "The tech concepts you should know in order to get a job as a Laravel developer.": "De tekniska koncepten du bör lära dig för att kunna få ett jobb som en Laravel-utvecklare",
+    "That's all, for now.": "Det var allt, tills vidare",
+    "Soon: more and better organized links to places to learn each of these technologies/tools, a more robust list of technologies, etc., and then later maybe exercises to test them and prove out your learning.": "Snart: Fler och bättre organisade länkar till ställen att lära sig var och en av dessa teknikerna och verktygen, en mer robust lista av teknologier, etc. Senare kanske även övningar för att testa och bekräfta vad du lärt dig",
+    "Log in": "Logga in",
+    "Register": "Registrera dig"
+}

--- a/resources/lang/sv/auth.php
+++ b/resources/lang/sv/auth.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Authentication Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used during authentication for various
+    | messages that we need to display to the user. You are free to modify
+    | these language lines according to your application's requirements.
+    |
+    */
+
+    'failed' => 'Felaktiga inloggningsuppgifter',
+    'throttle' => 'För många inloggningsförsök. Försök igen om :seconds sekunder.',
+
+];

--- a/resources/lang/sv/pagination.php
+++ b/resources/lang/sv/pagination.php
@@ -1,0 +1,19 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Pagination Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used by the paginator library to build
+    | the simple pagination links. You are free to change them to anything
+    | you want to customize your views to better match your application.
+    |
+    */
+
+    'previous' => '&laquo; Föregående',
+    'next' => 'Nästa &raquo;',
+
+];

--- a/resources/lang/sv/passwords.php
+++ b/resources/lang/sv/passwords.php
@@ -1,0 +1,22 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Password Reset Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are the default lines which match reasons
+    | that are given by the password broker for a password update attempt
+    | has failed, such as for an invalid token or invalid new password.
+    |
+    */
+
+    'password' => 'Lösenord måste vara minst 8 tecken och måste matcha bekräftelse-fältet',
+    'reset' => 'Ditt lösenord har blivit återställt!',
+    'sent' => 'Vi har mailat dig en länk för att återställa lösenordet!',
+    'token' => 'Din återställnings-token är felaktig.',
+    'user' => "Vi kan inte hitta användaren med den e-posten.",
+
+];

--- a/resources/lang/sv/validation.php
+++ b/resources/lang/sv/validation.php
@@ -1,0 +1,150 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines contain the default error messages used by
+    | the validator class. Some of these rules have multiple versions such
+    | as the size rules. Feel free to tweak each of these messages here.
+    |
+    */
+
+    'accepted' => 'Attributet :attribute måste accepteras.',
+    'active_url' => 'Attributet :attribute är inte en giltig URL.',
+    'after' => 'Attributet :attribute måste vara ett datum efter :date.',
+    'after_or_equal' => 'Attributet :attribute måste vara ett datum efter eller samma som :date.',
+    'alpha' => 'Attributet :attribute får bara innehålla bokstäver.',
+    'alpha_dash' => 'Attributet :attribute får bara innehålla bokstäver, siffror, - eller _.',
+    'alpha_num' => 'Attributet :attribute får bara innehålla bokstäver och siffror.',
+    'array' => 'Attributet :attribute måste vara en array.',
+    'before' => 'Attributet :attribute måste vara ett datum före :date.',
+    'before_or_equal' => 'Attributet :attribute måste vara ett datum före eller samma som :date.',
+    'between' => [
+        'numeric' => 'Attributet :attribute måste vara större än :min och mindre än :max.',
+        'file' => 'Attributet :attribute måste vara större än :min och mindre än :max kilobytes.',
+        'string' => 'Attributet :attribute måste vara större än :min och mindre :max tecken.',
+        'array' => 'Attributet :attribute måste ha fler än :min och mindre :max objekt.',
+    ],
+    'boolean' => 'Attributet :attribute måste vara sant eller falskt.',
+    'confirmed' => 'Attributet :attribute matchar inte bekräftelsefältet.',
+    'date' => 'Attributet :attribute är inte ett giltigt datum.',
+    'date_equals' => 'Attributet :attribute måste vara samma datum som :date.',
+    'date_format' => 'Attributet :attribute måste formatteras enligt :format.',
+    'different' => 'Attributet :attribute och :other får inte vara samma.',
+    'digits' => 'Attributet :attribute måste vara :digits siffror.',
+    'digits_between' => 'Attributet :attribute måste vara fler än :min och mindre än :max siffror.',
+    'dimensions' => 'Attributet :attribute är feldimensionerat.',
+    'distinct' => 'Attributet :attribute har ett duplicerat värde.',
+    'email' => 'Attributet :attribute måste vara en giltig email adress.',
+    'ends_with' => 'Attributet :attribute måste sluta med något av följande: :values',
+    'exists' => 'Det valda attributet ":attribute" är ogiltigt.',
+    'file' => 'Attributet :attribute måste vara en fil.',
+    'filled' => 'Attributet :attribute måste ha ett värde.',
+    'gt' => [
+        'numeric' => 'Attributet :attribute måste vara större än :value.',
+        'file' => 'Attributet :attribute  måste vara större än :value kilobytes.',
+        'string' => 'Attributet :attribute  måste vara större än :value tecken.',
+        'array' => 'Attributet :attribute måste ha fler än :value objekt.',
+    ],
+    'gte' => [
+        'numeric' => 'Attributet :attribute måste vara minst :value.',
+        'file' => 'Attributet :attribute får minst vara :value kilobytes.',
+        'string' => 'Attributet :attribute får minst vara :value characters.',
+        'array' => 'Attributet :attribute måste ha :value objekt eller fler.',
+    ],
+    'image' => 'Attributet :attribute måste vara en bild.',
+    'in' => 'Det valda attributet ":attribute" är ogiltigt.',
+    'in_array' => 'Attributet ":attribute" finns inte i :other.',
+    'integer' => 'Attributet ":attribute" måste vara en siffra.',
+    'ip' => 'Attributet :attribute måste vara en giltig IP address.',
+    'ipv4' => 'Attributet :attribute måste vara en giltig IPv4 address.',
+    'ipv6' => 'Attributet :attribute måste vara en giltig IPv6 address.',
+    'json' => 'Attributet :attribute måste vara en giltig JSON string.',
+    'lt' => [
+        'numeric' => 'Attributet :attribute måste vara mindre än :value.',
+        'file' => 'Attributet :attribute måste vara mindre än :value kilobytes.',
+        'string' => 'Attributet :attribute måste vara mindre än :value characters.',
+        'array' => 'Attributet :attribute måste ha färre än :value objekt.',
+    ],
+    'lte' => [
+        'numeric' => 'Attributet :attribute får bara vara mindre :value eller mindre.',
+        'file' => 'Attributet :attribute får bara vara :value kilobytes eller mindre.',
+        'string' => 'Attributet :attribute får max ha :value tecken.',
+        'array' => 'Attributet :attribute får inte ha fler än :value objekt.',
+    ],
+    'max' => [
+        'numeric' => 'Attributet :attribute får inte vara större än :max.',
+        'file' => 'Attributet :attribute får inte vara större än :max kilobytes.',
+        'string' => 'Attributet :attribute får inte vara större än :max characters.',
+        'array' => 'Attributet :attribute får inte vara ha fler än :max objekt.',
+    ],
+    'mimes' => 'Attributet :attribute måste vara av filtypen: :values.',
+    'mimetypes' => 'Attributet :attribute måste vara av filtypen: :values.',
+    'min' => [
+        'numeric' => 'Attributet :attribute måste åtminstone vara :min.',
+        'file' => 'Attributet :attribute måste åtminstone vara :min kilobytes.',
+        'string' => 'Attributet :attribute måste åtminstone vara :min tecken.',
+        'array' => 'Attributet :attribute måste ha minst :min objekt.',
+    ],
+    'not_in' => 'Det valda attributet ":attribute" är ogiltigt.',
+    'not_regex' => 'Formatet på attributet :attribute är ogiltigt.',
+    'numeric' => 'Attributet :attribute måste vara ett nummer.',
+    'present' => 'Attributet :attribute måste finnas med.',
+    'regex' => 'Formatet på attributet ":attribute" är ogiltigt.',
+    'required' => 'Attributet :attribute är obligatoriskt.',
+    'required_if' => 'Attributet :attribute är obligatoriskt om :other är :value.',
+    'required_unless' => 'Attributet :attribute om inte :other är en av: :values.',
+    'required_with' => 'Attributet :attribute är obligatoriskt om :values finns.',
+    'required_with_all' => 'Attributet :attribute är obligatoriskt om :values finns.',
+    'required_without' => 'Attributet :attribute är obligatoriskt om :values inte finns.',
+    'required_without_all' => 'Attributet :attribute är obligatoriskt om :values finns.',
+    'same' => 'Attributen :attribute och :other måste matcha.',
+    'size' => [
+        'numeric' => 'Attributet :attribute måste vara :size.',
+        'file' => 'Attributet :attribute måste vara :size kilobyte.',
+        'string' => 'Attributet :attribute måste vara :size tecken.',
+        'array' => 'Attributet :attribute måste innehålla :size objekt.',
+    ],
+    'starts_with' => 'Attributet :attribute måste börja med en av följande: :values',
+    'string' => 'Attributet :attribute måste vara en sträng.',
+    'timezone' => 'Attributet :attribute måste vara en giltig tidszon.',
+    'unique' => 'Attributet :attribute har redan använts.',
+    'uploaded' => ':attribute misslyckades laddas upp.',
+    'url' => 'Formatet på attributet :attribute är ogiltigt.',
+    'uuid' => 'Attributet :attribute måste vara ett giltigt UUID.',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Language Lines
+    |--------------------------------------------------------------------------
+    |
+    | Here you may specify custom validation messages for attributes using the
+    | convention "attribute.rule" to name the lines. This makes it quick to
+    | specify a specific custom language line for a given attribute rule.
+    |
+    */
+
+    'custom' => [
+        'attribute-name' => [
+            'rule-name' => 'custom-message',
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Custom Validation Attributes
+    |--------------------------------------------------------------------------
+    |
+    | The following language lines are used to swap our attribute placeholder
+    | with something more reader friendly such as "E-Mail Address" instead
+    | of "email". This simply helps us make our message more expressive.
+    |
+    */
+
+    'attributes' => [],
+
+];

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,10 +17,10 @@
         <!-- header -->
         <header class="w-full px-6 text-white" style="background: #3f51d8">
             <div class="container mx-auto max-w-4xl md:flex justify-between items-center">
-                <a href="{{ url_wlocale('/') }}" class="block py-6 w-full text-center md:text-left flex justify-left items-center">
+                <a href="{{ url_wlocale('/') }}" class="block py-6 flex-grow text-center md:text-left flex justify-left items-center">
                     <img src="/images/onramp_logo.svg" alt="Onramp" class="max-w-xs w-full">
                 </a>
-                <div class="text-white text-center md:text-right md:w-40">
+                <div class="text-white text-center md:text-right">
                 @foreach (Facades\App\Localization\Locale::all() as $thisLocale)
                     <a href="{{ switch_locale_link($thisLocale) }}" class="text-white text-sm p-3{{ $thisLocale === $locale ? ' font-bold' : '' }}">{{ strtoupper($thisLocale) }}</a>
                     @if (! $loop->last)

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -6,7 +6,7 @@
     <div class="text-center px-6 py-12 mb-6 bg-gray-100 border-b">
         <h1 class=" text-xl md:text-4xl pb-4">{{ __('Onramp to Laravel') }}</h1>
         <p class="leading-loose text-gray-dark">
-            Providing an easy entrance to Laravel for new developers
+            {{__('Providing an easy entrance to Laravel for new developers')}}
         </p>
     </div>
     <!-- /title -->


### PR DESCRIPTION
In the last stream Matt was talking about having more translations of onramp.
Since I just dipped my toes in and built the glossary stuff, I thought that a Swedish translation could be worth while as well.

By adding a new language to the list, I changed the width of the logotype form w-full to flex-grow. That way it takes up the space it needs, and leaves room for the list of translations.
You might want it to be a multi row list, but it looked weird with only 3 languages.

![image](https://user-images.githubusercontent.com/330839/66708942-faf8ea80-ed59-11e9-9caf-d8ce62d4f3a9.png)
