### PR TITLE
Add Frontend Masters content and re-added "Git - The Simple guide"

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -38,6 +38,7 @@ class DatabaseSeeder extends Seeder
                 'resources' => [
                     'Intro to HTML at CSS-tricks' => 'https://www.yay.com/',
                     'Intro to CSS at CSS-tricks' => 'https://www.superyay.com/',
+                    'Frontend Masters' =>  'https://frontendmasters.com/bootcamp/',
                 ],
             ],
             [
@@ -50,6 +51,7 @@ class DatabaseSeeder extends Seeder
                 'resources' => [
                     'Intro to Git at Tower' => 'https://www.tower.com/',
                     'Intro to Git branching at Gitlab' => 'https://www.superyay.com/',
+                    'Git - The Simple Guide' => 'https://rogerdudler.github.io/git-guide/'
                 ],
             ],
             [


### PR DESCRIPTION
I was looking through the issues and found a couple of easy ones to add.

I saw that Git simple guide was removed since the transformation to DB storage, so I re-added it.

closes #45