### PR TITLE
Get the selected locale from the app instance and default to en

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -3,7 +3,7 @@
 
 Route::redirect('/', '/en');
 
-Route::group(['prefix' => '{locale}'], function () {
+Route::group(['prefix' => app()->getLocale() ?? 'en'], function () {
     Route::view('/', 'welcome');
 
     Route::get('learn', 'LearnController');


### PR DESCRIPTION
This PR will make the application grab its locale from the `app()` instance instead of passing a `$locale` variable each time we call a `route()` helper.
This way you are no longer in need for the `route_wlocale` helpers anymore and back to use the normal `route()`