### PR TITLE
Add additional environment check to get the proper locale in console

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -30,8 +30,9 @@ class AppServiceProvider extends ServiceProvider
 
         if ($this->app->environment() !== 'testing') {
             Event::subscribe(SlackSubscriber::class);
-
-            $locale = locale();
+            if ( ! $this->app->runningInConsole()) {
+                $locale = locale();
+            }
         }
 
         $this->app->setlocale($locale);


### PR DESCRIPTION
The locale will become the equivalent of 'not-any' by default when running console commands.
This PR updates the AppServiceProvider and checks if we're not in console mode and then sets the locale accordingly.

Before:
![image](https://user-images.githubusercontent.com/330839/66934716-384fc780-f03b-11e9-8c28-a41e41b11eef.png)

After:
<img width="668" alt="image" src="https://user-images.githubusercontent.com/330839/66934788-5289a580-f03b-11e9-955d-2f7d2548dc24.png">
