### PR TITLE
Add back database seeding for glossary terms.

### DIFF
--- a/database/seeds/ExistingContentSeeder.php
+++ b/database/seeds/ExistingContentSeeder.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Module;
+use App\Term;
 use App\Track;
 use Illuminate\Database\Seeder;
 
@@ -21,6 +22,10 @@ class ExistingContentSeeder extends Seeder
 
             $this->createResources($moduleArray, $module);
             $this->createSkills($moduleArray, $module);
+        });
+
+        collect(require('glossary.php'))->each(function ($term){
+            Term::create($term);
         });
     }
 

--- a/database/seeds/glossary.php
+++ b/database/seeds/glossary.php
@@ -4,11 +4,9 @@ return [
     [
         'name' => [
             'en' => 'collections',
-            'es' => 'colecciones',
         ],
         'description' => [
-            'en' => 'A Collection is a convenient wrapper for working with arrays of data.',
-            'es' => 'Collection description but in Spanish',
+            'en' => 'A Laravel Collection is a convenient wrapper around arrays providing methods for manipulating the array data in useful ways.',
         ],
     ],
     [
@@ -16,9 +14,7 @@ return [
             'en' => 'HTML',
         ],
         'description' => [
-            'en' => 'HTML description in english',
-            'es' => 'HTML description but in Spanish',
-            'de' => 'HTML description but in German',
+            'en' => 'HTML (Hypertext Markup Language) is the primary language used to represent content on web pages. For example, it allows the the web browser to determine which parts of the content are headings, which parts are paragraph text and which parts should be formatted as tables.',
         ],
     ],
     [
@@ -26,7 +22,7 @@ return [
             'en' => 'CSS',
         ],
         'description' => [
-            'en' => 'CSS description in english',
+            'en' => 'CSS (Cascading Style Sheet) is the primary language used on web pages to describe what visual appearance content should have. For example, it allows the the web browser to determine what size text should be, what color the background of a heading should be or the spacing between two elements on the page.',
         ],
     ],
 ];

--- a/database/seeds/glossary.php
+++ b/database/seeds/glossary.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    [
+        'name' => [
+            'en' => 'collections',
+            'es' => 'colecciones',
+        ],
+        'description' => [
+            'en' => 'A Collection is a convenient wrapper for working with arrays of data.',
+            'es' => 'Collection description but in Spanish',
+        ],
+    ],
+    [
+        'name' => [
+            'es' => 'HTML',
+        ],
+        'description' => [
+            'en' => 'HTML description in english',
+            'es' => 'HTML description but in Spanish',
+            'de' => 'HTML description but in German',
+        ],
+    ],
+    [
+        'name' => [
+            'en' => 'CSS',
+        ],
+        'description' => [
+            'en' => 'CSS description in english',
+        ],
+    ],
+];

--- a/database/seeds/glossary.php
+++ b/database/seeds/glossary.php
@@ -13,7 +13,7 @@ return [
     ],
     [
         'name' => [
-            'es' => 'HTML',
+            'en' => 'HTML',
         ],
         'description' => [
             'en' => 'HTML description in english',

--- a/resources/views/glossary.blade.php
+++ b/resources/views/glossary.blade.php
@@ -23,7 +23,7 @@
                                 {{ $term->getTranslation('name', locale()) }}
                             </h3>
                             @if ($term->name !== $term->getEnglishName())
-                                <span class="pl-1 text-grey-800 capitalize text-sm">({{ $term->getEnglishName() }} )</span>
+                                <span class="pl-1 text-grey-800 capitalize text-sm">({{ $term->getEnglishName() }})</span>
                             @endif
                         </div>
                         <p class="mt-2">{{ $term->getTranslation('description', locale()) }}</p>


### PR DESCRIPTION
This PR adds back database seeding for glossary terms.

- The same pattern used for seeding learning resources is used for seeding glossary terms—A php file (`glossary.php`) containing the data in array format which is required in `ExistingContentSeeder.php` and iterated over.

![Screenshot 2019-10-18 at 21 34 03](https://user-images.githubusercontent.com/1974648/67126490-18f99b80-f1ef-11e9-85ee-ccc33b0f4429.png)