### PR TITLE
Fix broken footer on mobile 

### DIFF
--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -77,9 +77,9 @@
             <!-- footer -->
             <footer class="w-full bg-white px-6 border-t">
                 <div
-                    class="container mx-auto max-w-4xl py-6 flex flex-wrap md:flex-no-wrap justify-between items-center text-sm">
+                    class="container mx-auto max-w-4xl py-6 flex flex-wrap md:flex-no-wrap justify-between items-end text-sm">
                     <p>{{ __('From the lovely folks at') }} <a href="https://tighten.co/">Tighten.</a></p>
-                    <div class="pt-4 md:p-0 text-center md:text-right text-xs">
+                    <div class="text-center md:text-right text-xs">
                         <a href="https://github.com/tightenco/onramp">{{ __('Source & Roadmap') }}</a>
                         {{--
                         <a href="#" class="text-black ml-4">Terms &amp; Conditions</a>


### PR DESCRIPTION
This fixes a broken footer layout on the mobile screen. Closes issue #88.

- Removed class `items-center` and added class `items-end` to the `footer>div.container`
- Removed classes `pt-4` and `md:p-0` from the `footer>div.container>div`