### PR TITLE
Fix confusing language filter on the module page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /node_modules
+/public/css
+/public/js
 /public/hot
 /public/storage
 /storage/*.key

--- a/resources/views/modules/show.blade.php
+++ b/resources/views/modules/show.blade.php
@@ -17,8 +17,10 @@
         <div class="w-full md:pr-12 mb-6">
 
             <p class="mb-8 text-right text-sm">
-                <a href="javascript:alert('Not programmed yet @todo');" class="font-bold">Show only resources for {{ locale() }}</a> |
-                <a href="javascript:alert('Not programmed yet @todo');">Show only {{ locale() }} and English resources</a> |
+                <a href="javascript:alert('Not programmed yet @todo');" class="font-bold">Show only resources in {{ Facades\App\Localization\Locale::languageForLocale(locale()) }}</a> |
+                @if('en' !== locale())
+                    <a href="javascript:alert('Not programmed yet @todo');">Show only {{ Facades\App\Localization\Locale::languageForLocale(locale()) }} and English resources</a> |
+                @endif
                 <a href="javascript:alert('Not programmed yet @todo');">Show all resources</a>
             </p>
 


### PR DESCRIPTION
This PR addresses Issue #95

The current language filter on the modules page is confusing. Assuming the locale is set to English, It is currently formatted as follows:

![Screenshot 2019-10-19 at 14 28 29](https://user-images.githubusercontent.com/1974648/67145840-dd0d1780-f27c-11e9-9c39-67cf0b94b51e.png)

This is problematic for two reasons:

1. It uses the two letter locale–en in this case–to indicate the language.
1. When English is set as the language, it doesn't make sense to have the second option.

This PR changes the filter as follows:

It uses the full language name in place of the two letter locale.

![Screenshot 2019-10-19 at 14 33 22](https://user-images.githubusercontent.com/1974648/67145895-72101080-f27d-11e9-8f6d-5035ae359d79.png)

It removes the second option when the user has selected English as their preferred language.

![Screenshot 2019-10-19 at 14 32 31](https://user-images.githubusercontent.com/1974648/67145887-51e05180-f27d-11e9-9ca1-36c673aef8b6.png)

**Out of scope of this PR:**

- Translation of the full option sentences in the filter. Only the translated language name has replaced the two letter locale.
- Implementing the actual filter functionality.