### PR TITLE
Combine two table of contents into one

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -22,7 +22,7 @@ window.Vue = require('vue');
 // Vue.component('language-switcher', require('./components/LanguageSwitcher.vue').default);
 
 import LanguageSwitcher from './components/LanguageSwitcher.vue'
-import Toggle from './components/Toggle.vue'
+import ToggleWhenMobile from './components/ToggleWhenMobile.vue'
 
 /**
  * Next, we will create a fresh Vue application instance and attach it to
@@ -33,7 +33,7 @@ import Toggle from './components/Toggle.vue'
 const app = new Vue({
     components: {
         'language-switcher': LanguageSwitcher,
-        'toggle': Toggle
+        'toggle-when-mobile': ToggleWhenMobile
     },
     el: '#app',
 });

--- a/resources/js/components/Toggle.vue
+++ b/resources/js/components/Toggle.vue
@@ -1,8 +1,8 @@
 <template>
     <div>
-        <button @click="toggle" class="border rounded py-1 px-4">{{ buttonLabel }}</button>
+        <button @click="toggle" class="border rounded py-1 px-4 md:hidden">{{ buttonLabel }}</button>
 
-        <div v-show="isOpen" :aria-hidden="!isOpen">
+        <div v-show="tableOfContentsVisible" class="mb-2">
             <slot></slot>
         </div>
     </div>
@@ -26,6 +26,12 @@
             buttonLabel() {
                 return this.isOpen ? 'Hide' : 'Show';
             },
+            tableOfContentsVisible() {
+                if (window.innerWidth >= 768) {
+                    this.isOpen = true;
+                };
+                return this.isOpen;
+            }
         },
     }
 </script>

--- a/resources/js/components/ToggleWhenMobile.vue
+++ b/resources/js/components/ToggleWhenMobile.vue
@@ -2,7 +2,7 @@
     <div>
         <button @click="toggle" class="border rounded py-1 px-4 md:hidden">{{ buttonLabel }}</button>
 
-        <div v-show="tableOfContentsVisible" class="mb-2">
+        <div v-show="slotVisible" class="mb-2">
             <slot></slot>
         </div>
     </div>
@@ -26,7 +26,7 @@
             buttonLabel() {
                 return this.isOpen ? 'Hide' : 'Show';
             },
-            tableOfContentsVisible() {
+            slotVisible() {
                 if (window.innerWidth >= 768) {
                     this.isOpen = true;
                 };

--- a/resources/js/components/ToggleWhenMobile.vue
+++ b/resources/js/components/ToggleWhenMobile.vue
@@ -2,7 +2,7 @@
     <div>
         <button @click="toggle" class="border rounded py-1 px-4 md:hidden">{{ buttonLabel }}</button>
 
-        <div v-show="slotVisible" class="mb-2">
+        <div class="mb-2 md:block" v-bind:class="{ hidden: !isOpen }">
             <slot></slot>
         </div>
     </div>
@@ -26,12 +26,6 @@
             buttonLabel() {
                 return this.isOpen ? 'Hide' : 'Show';
             },
-            slotVisible() {
-                if (window.innerWidth >= 768) {
-                    this.isOpen = true;
-                };
-                return this.isOpen;
-            }
         },
     }
 </script>

--- a/resources/views/glossary.blade.php
+++ b/resources/views/glossary.blade.php
@@ -34,7 +34,7 @@
                 <div class="md:mt-10 mb-4 pb-4 w-full md:w-1/4 border-b border-grey-100 md:border-none">
                     <h3 class="text-xl">{{ __('Table of contents') }}</h3>
                     <toggle-when-mobile>
-                        <ul class="mt-4 md:block md:border-b">
+                        <ul class="mt-4 md:border-b">
                             @forelse ($terms as $term)
                                 <li class="leading-relaxed list-disc md:list-none ml-4 md:ml-0 pl-1 md:pl-0">
                                     <a class="capitalize" href="#{{ $term->getEnglishName() }}">{{ $term->name }}</a>

--- a/resources/views/glossary.blade.php
+++ b/resources/views/glossary.blade.php
@@ -33,11 +33,10 @@
                 </ul>
                 <div class="md:mt-10 mb-4 pb-4 w-full md:w-1/4 border-b border-grey-100 md:border-none">
                     <h3 class="text-xl">{{ __('Table of contents') }}</h3>
-                    <!-- Mobile -->
-                    <toggle class="mb-2 md:hidden">
-                        <ul class="mt-4">
+                    <toggle>
+                        <ul class="mt-4 md:block md:border-b">
                             @forelse ($terms as $term)
-                                <li class="leading-relaxed list-disc ml-4 pl-1">
+                                <li class="leading-relaxed list-disc md:list-none ml-4 md:ml-0 pl-1 md:pl-0">
                                     <a class="capitalize" href="#{{ $term->getEnglishName() }}">{{ $term->name }}</a>
                                 </li>
                             @empty
@@ -45,17 +44,6 @@
                             @endforelse
                         </ul>
                     </toggle>
-
-                    <!-- Desktop -->
-                    <ul class="mt-4 hidden md:block">
-                        @forelse ($terms as $term)
-                            <li class="leading-relaxed">
-                                <a class="capitalize" href="#{{ $term->getEnglishName() }}">{{ $term->name }}</a>
-                            </li>
-                        @empty
-                            {{ __('No terms') }}
-                        @endforelse
-                    </ul>
                 </div>
             </div>
         </div>

--- a/resources/views/glossary.blade.php
+++ b/resources/views/glossary.blade.php
@@ -33,7 +33,7 @@
                 </ul>
                 <div class="md:mt-10 mb-4 pb-4 w-full md:w-1/4 border-b border-grey-100 md:border-none">
                     <h3 class="text-xl">{{ __('Table of contents') }}</h3>
-                    <toggle>
+                    <toggle-when-mobile>
                         <ul class="mt-4 md:block md:border-b">
                             @forelse ($terms as $term)
                                 <li class="leading-relaxed list-disc md:list-none ml-4 md:ml-0 pl-1 md:pl-0">
@@ -43,7 +43,7 @@
                                 {{ __('No terms') }}
                             @endforelse
                         </ul>
-                    </toggle>
+                    </toggle-when-mobile>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
I've merged the two table of contents into one. They are both shown differently if on mobile or desktop. As mention in Issue [#96](https://github.com/tightenco/onramp/issues/96) aria-hidden could be removed since we just have one table of contents left.