### PR TITLE
Fix intermittent test failure for resources related to glossary terms (Issue #109)

### DIFF
--- a/tests/Feature/GlossaryRelationsTest.php
+++ b/tests/Feature/GlossaryRelationsTest.php
@@ -12,7 +12,7 @@ class GlossaryRelationsTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    function glossary_page_shows_related_resources_in_the_current_locale()
+    function glossary_page_shows_related_resources()
     {
         $currentLocale = 'en';
         $resource = factory(Resource::class)->create(['language' => $currentLocale]);

--- a/tests/Feature/GlossaryRelationsTest.php
+++ b/tests/Feature/GlossaryRelationsTest.php
@@ -12,18 +12,38 @@ class GlossaryRelationsTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    function glossary_page_shows_related_resources()
+    function glossary_page_shows_related_resources_in_the_current_locale()
     {
-        $resource = factory(Resource::class)->create();
-        $otherResource = factory(Resource::class)->create();
+        $currentLocale = 'en';
+        $resource = factory(Resource::class)->create(['language' => $currentLocale]);
+        $otherResource = factory(Resource::class)->create(['language' => $currentLocale]);
         $term = factory(Term::class)->create();
 
         $term->resources()->save($resource);
 
         $this->assertContains($resource->id, $term->fresh()->resources()->pluck('resources.id'));
 
-        $response = $this->get('/en/glossary');
+        $response = $this->get("/${currentLocale}/glossary");
         $response->assertSee($resource->name);
         $response->assertDontSee($otherResource->name);
+    }
+
+    /** @test */
+    function glossary_page_hides_related_resources_not_in_the_current_locale()
+    {
+        $currentLocale = 'en';
+        $englishResource = factory(Resource::class)->create(['language' => $currentLocale]);
+        $spanishResource = factory(Resource::class)->create(['language' => 'es']);
+        $term = factory(Term::class)->create();
+
+        $term->resources()->saveMany([$englishResource, $spanishResource]);
+
+        $this->assertContains($englishResource->id, $term->fresh()->resources()->pluck('resources.id'));
+        $this->assertContains($spanishResource->id, $term->fresh()->resources()->pluck('resources.id'));
+        $this->assertNotContains($spanishResource->id, $term->fresh()->resourcesForUser()->pluck('resources.id'));
+
+        $response = $this->get("/${currentLocale}/glossary");
+        $response->assertSee($englishResource->name);
+        $response->assertDontSee($spanishResource->name);
     }
 }


### PR DESCRIPTION
This PR fixes #109 Fix intermittent test failure for resources related to glossary terms.

This issue is related to the resource factory randomly creating resources in either English (en) or Spanish (es) but the test always gets the page with the english local `/en/glossary`. If the factory created the resource in Spanish the glossary page would correctly hide it as the locale being requested was english. The test therefore fails as the name of the resource is not in the page.