### PR TITLE
Add optional bonus modules (closes #104)

### DIFF
--- a/app/Http/Controllers/ModuleController.php
+++ b/app/Http/Controllers/ModuleController.php
@@ -10,7 +10,8 @@ class ModuleController extends Controller
     {
         return view('modules.index', [
             'pageTitle' => 'Modules',
-            'modules' => Module::all(),
+            'standardModules' => Module::standard()->get(),
+            'bonusModules' => Module::bonus()->get(),
             'completedModules' => auth()->check() ? auth()->user()->moduleCompletions()->pluck('completable_id') : collect([]),
         ]);
     }

--- a/app/Module.php
+++ b/app/Module.php
@@ -47,4 +47,14 @@ class Module extends Model implements Completable
     {
         return $this->resources()->forUser($user ?? auth()->user());
     }
+
+    public function scopeStandard($query)
+    {
+        return $query->where('is_bonus', 0);
+    }
+
+    public function scopeBonus($query)
+    {
+        return $query->where('is_bonus', 1);
+    }
 }

--- a/database/factories/ModuleFactory.php
+++ b/database/factories/ModuleFactory.php
@@ -9,5 +9,6 @@ $factory->define(Module::class, function (Faker $faker) {
         'slug' => function ($module) {
             return Str::slug($module['name']);
         },
+        'is_bonus' => $faker->boolean(20),
     ];
 });

--- a/database/migrations/2019_10_24_152519_add_is_bonus_to_modules_table.php
+++ b/database/migrations/2019_10_24_152519_add_is_bonus_to_modules_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddIsBonusToModulesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('modules', function (Blueprint $table) {
+            $table->boolean('is_bonus')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('modules', function (Blueprint $table) {
+            $table->dropColumn('is_bonus');
+        });
+    }
+}

--- a/resources/views/modules/index.blade.php
+++ b/resources/views/modules/index.blade.php
@@ -28,7 +28,7 @@
                 @endforeach
             </ul>
 
-            @if($bonusModules->count() > 0)
+            @if ($bonusModules->count() > 0)
             <p class="my-2">The following bonus modules are optional:</p>
 
             <ul class="list-disc pl-6">

--- a/resources/views/modules/index.blade.php
+++ b/resources/views/modules/index.blade.php
@@ -15,10 +15,10 @@
 
     <div class="container max-w-4xl mx-auto md:flex items-start mt-6 py-8 px-12 md:px-0">
         <div class="w-full md:pr-12 mb-6">
-            Here are all of the modules we'll eventually use to cover all of our content:<br><br>
+            <p class="mb-2">Here are all of the modules we'll eventually use to cover all of our content:</p>
 
             <ul class="list-disc pl-6">
-                @foreach ($modules as $module)
+                @foreach ($standardModules as $module)
                 <li>
                     @auth
                     <!--input type="checkbox" disabled {{ $completedModules->contains($module->id) ? ' checked="checked"' : '' }}-->
@@ -27,6 +27,21 @@
                 </li>
                 @endforeach
             </ul>
+
+            @if($bonusModules->count() > 0)
+            <p class="my-2">The following bonus modules are optional:</p>
+
+            <ul class="list-disc pl-6">
+                @foreach ($bonusModules as $module)
+                <li>
+                    @auth
+                    <!--input type="checkbox" disabled {{ $completedModules->contains($module->id) ? ' checked="checked"' : '' }}-->
+                    @endauth
+                    <a href="{{ route_wlocale('modules.show', $module) }}">{{ $module->name }}</a>
+                </li>
+                @endforeach
+            </ul>
+            @endif
         </div>
     </div>
 </div>

--- a/tests/Feature/ModulesTest.php
+++ b/tests/Feature/ModulesTest.php
@@ -12,7 +12,7 @@ class ModulesTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    function modules_can_be_seen()
+    function module_index_page_lists_modules()
     {
         $standardModule = factory(Module::class)->create([
             'name' => 'Standard module',

--- a/tests/Feature/ModulesTest.php
+++ b/tests/Feature/ModulesTest.php
@@ -47,9 +47,15 @@ class ModulesTest extends TestCase
 
         $response = $this->get("/en/modules");
 
-        $this->assertTrue(count($this->getResponseData($response, 'standardModules')) == 1);
-        $this->assertTrue($this->getResponseData($response, 'standardModules')[0]->name == $standardModule->name);
-        $this->assertFalse($this->getResponseData($response, 'standardModules')[0]->name == $bonusModule->name);
+        $response->assertViewHas('standardModules', function($standardModules) {
+            return $standardModules->count() == 1;
+        });
+        $response->assertViewHas('standardModules', function($standardModules) use ($standardModule) {
+            return $standardModules->contains($standardModule);
+        });
+        $response->assertViewHas('standardModules', function($standardModules) use ($bonusModule) {
+            return !$standardModules->contains($bonusModule);
+        });
     }
 
     /** @test */
@@ -67,8 +73,14 @@ class ModulesTest extends TestCase
 
         $response = $this->get("/en/modules");
 
-        $this->assertTrue(count($this->getResponseData($response, 'bonusModules')) == 1);
-        $this->assertTrue($this->getResponseData($response, 'bonusModules')[0]->name == $bonusModule->name);
-        $this->assertFalse($this->getResponseData($response, 'bonusModules')[0]->name == $standardModule->name);
+        $response->assertViewHas('standardModules', function($bonusModules) {
+            return $bonusModules->count() == 1;
+        });
+        $response->assertViewHas('bonusModules', function($bonusModules) use ($bonusModule) {
+            return $bonusModules->contains($bonusModule);
+        });
+        $response->assertViewHas('bonusModules', function($bonusModules) use ($standardModule) {
+            return !$bonusModules->contains($standardModule);
+        });
     }
 }

--- a/tests/Feature/ModulesTest.php
+++ b/tests/Feature/ModulesTest.php
@@ -31,4 +31,44 @@ class ModulesTest extends TestCase
             $bonusModule->name,
         ]);
     }
+
+    /** @test */
+    function list_of_standard_modules_only_contains_standard_modules()
+    {
+        $standardModule = factory(Module::class)->create([
+            'name' => 'Standard module',
+            'is_bonus' => 0,
+        ]);
+
+        $bonusModule = factory(Module::class)->create([
+            'name' => 'Bonus module',
+            'is_bonus' => 1,
+        ]);
+
+        $response = $this->get("/en/modules");
+
+        $this->assertTrue(count($this->getResponseData($response, 'standardModules')) == 1);
+        $this->assertTrue($this->getResponseData($response, 'standardModules')[0]->name == $standardModule->name);
+        $this->assertFalse($this->getResponseData($response, 'standardModules')[0]->name == $bonusModule->name);
+    }
+
+    /** @test */
+    function list_of_bonus_modules_only_contains_bonus_modules()
+    {
+        $standardModule = factory(Module::class)->create([
+            'name' => 'Standard module',
+            'is_bonus' => 0,
+        ]);
+
+        $bonusModule = factory(Module::class)->create([
+            'name' => 'Bonus module',
+            'is_bonus' => 1,
+        ]);
+
+        $response = $this->get("/en/modules");
+
+        $this->assertTrue(count($this->getResponseData($response, 'bonusModules')) == 1);
+        $this->assertTrue($this->getResponseData($response, 'bonusModules')[0]->name == $bonusModule->name);
+        $this->assertFalse($this->getResponseData($response, 'bonusModules')[0]->name == $standardModule->name);
+    }
 }

--- a/tests/Feature/ModulesTest.php
+++ b/tests/Feature/ModulesTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Module;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ModulesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function modules_can_be_seen()
+    {
+        $standardModule = factory(Module::class)->create([
+            'name' => 'Standard module',
+            'is_bonus' => 0,
+        ]);
+
+        $bonusModule = factory(Module::class)->create([
+            'name' => 'Bonus module',
+            'is_bonus' => 1,
+        ]);
+
+        $response = $this->get("/en/modules");
+
+        $response->assertSeeInOrder([
+            $standardModule->name,
+            $bonusModule->name,
+        ]);
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,8 +7,4 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
-
-    function getResponseData($response, $key){
-        return $response->getOriginalContent()->getData()[$key]->all();
-    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,8 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    function getResponseData($response, $key){
+        return $response->getOriginalContent()->getData()[$key]->all();
+    }
 }


### PR DESCRIPTION
This PR closes #104 and adds the ability to separate modules in standard and bonus modules. Test coverage could be extended if required.