### PR TITLE
Update Czech translations

### DIFF
--- a/app/Localization/Locale.php
+++ b/app/Localization/Locale.php
@@ -13,7 +13,7 @@ class Locale
         'sv' => 'Svenska',
         'de' => 'Deutsch',
         'da' => 'Dansk',
-        'cs' => 'Česky',
+        'cs' => 'Čeština',
         'id' => 'Bahasa'
     ];
 

--- a/resources/lang/cs.json
+++ b/resources/lang/cs.json
@@ -40,5 +40,8 @@
     "Already have an account?": "Máte již účet?",
     "From the lovely folks at": "Od milých lidí v",
     "Source & Roadmap": "Zdroj & Plán projektu",
-    "Table of contents": "Obsah"
+    "Table of contents": "Obsah",
+    "All resources": "Všechny zdroje",
+    ":locale resources": ":locale zdroje",
+    "English and :locale resources": "Anglické a :locale zdroje"
 }


### PR DESCRIPTION
This PR references issue #143 , adding additional translations to be used in the resource language preference switcher.

- Czech translations added
- Czech language changed from 'Česky' to 'Čeština' (a different form of the word).
