### PR TITLE
Fix czech grammar in cs.json

### DIFF
--- a/resources/lang/cs.json
+++ b/resources/lang/cs.json
@@ -42,6 +42,6 @@
     "Source & Roadmap": "Zdroj & Plán projektu",
     "Table of contents": "Obsah",
     "All resources": "Všechny zdroje",
-    ":locale resources": ":locale zdroje",
-    "English and :locale resources": "Anglické a :locale zdroje"
+    ":locale resources": "Zdroje v čestině",
+    "English and :locale resources": "Anglické a české zdroje"
 }


### PR DESCRIPTION
This PR references issue #143.

I updated the Czech translation file, removed `:locale` and added the Czech adjective instead.