### PR TITLE
Fix issue 154 - language switcher failure

### DIFF
--- a/app/Http/Controllers/PreferenceController.php
+++ b/app/Http/Controllers/PreferenceController.php
@@ -17,7 +17,7 @@ class PreferenceController extends Controller
         ]);
     }
 
-    public function store(Request $request)
+    public function update(Request $request)
     {
         $request->validate([
             'resource-language' => 'required',

--- a/app/Http/Controllers/PreferenceController.php
+++ b/app/Http/Controllers/PreferenceController.php
@@ -19,17 +19,13 @@ class PreferenceController extends Controller
 
     public function update(Request $request)
     {
-        $request->validate([
-            'resource-language' => 'required',
-            'locale' => 'required',
-            'operating-system' => 'required',
-        ]);
+        $validKeys = $request->only(Preferences::getValidKeys());
 
-        Preferences::set([
-            'resource-language' => $request->input('resource-language'),
-            'locale' => $request->input('locale'),
-            'operating-system' => $request->input('operating-system'),
-        ]);
+        $filtered = array_filter($validKeys, function($val){
+            return $val !== null;
+        });
+
+        Preferences::set($filtered);
 
         if (auth()->user() && $request->filled('track')) {
             auth()->user()->track_id = $request->input('track');

--- a/app/Http/Controllers/PreferenceController.php
+++ b/app/Http/Controllers/PreferenceController.php
@@ -19,13 +19,9 @@ class PreferenceController extends Controller
 
     public function update(Request $request)
     {
-        $validKeys = $request->only(Preferences::getValidKeys());
-
-        $filtered = array_filter($validKeys, function($val){
-            return $val !== null;
-        });
-
-        Preferences::set($filtered);
+        Preferences::set(
+            collect($request->only(Preferences::getValidKeys()))->filter()
+        );
 
         if (auth()->user() && $request->filled('track')) {
             auth()->user()->track_id = $request->input('track');

--- a/app/Preferences/Preferences.php
+++ b/app/Preferences/Preferences.php
@@ -4,6 +4,7 @@ namespace App\Preferences;
 
 use App\User;
 use Exception;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cookie;
 
 class Preferences
@@ -21,15 +22,19 @@ class Preferences
         $this->user = $user;
     }
 
-    public function set(array $array)
+    public function set($preferences)
     {
-        foreach ($array as $key => $value) {
+        if ($preferences instanceof Collection) {
+            $preferences = $preferences->toArray();
+        }
+
+        foreach ($preferences as $key => $value) {
             $this->preferenceForKey($key)->validate($value);
             Cookie::queue($this->cookieNameForKey($key), $value, $this->cookieLength);
         }
 
         if ($this->user) {
-            $this->user->preferences = array_merge((array) $this->user->preferences, $array);
+            $this->user->preferences = array_merge((array) $this->user->preferences, $preferences);
             $this->user->save();
         }
     }

--- a/app/Preferences/Preferences.php
+++ b/app/Preferences/Preferences.php
@@ -71,4 +71,9 @@ class Preferences
     {
         return 'PREFERENCES::' . $key;
     }
+
+    public function getValidKeys()
+    {
+        return array_keys($this->preferences);
+    }
 }

--- a/resources/js/components/ResourceLanguagePreferenceSwitcher.vue
+++ b/resources/js/components/ResourceLanguagePreferenceSwitcher.vue
@@ -42,7 +42,7 @@
         methods: {
             choose(value) {
                 this.choice = value;
-                axios.post(route('user.preferences.store', {'locale': 'en'}), {
+                axios.patch(route('user.preferences.update', {'locale': 'en'}), {
                     'resource-language': value,
                 })
                 .then(function () {

--- a/resources/views/preferences.blade.php
+++ b/resources/views/preferences.blade.php
@@ -17,7 +17,8 @@ $resourceLanguagePreferenceKey = 'resource-language';
                 {{ __('Account Preferences') }}
             </h2>
 
-            <form method="post" action="{{ route_wlocale('user.preferences.store') }}">
+            <form method="post" action="{{ route_wlocale('user.preferences.update') }}">
+                @method('PATCH')
                 @csrf
                 <div class="mb-6">
                     <label for="{{ $localePreferenceKey }}" id="locale-label">
@@ -76,7 +77,7 @@ $resourceLanguagePreferenceKey = 'resource-language';
                             <option value="{{ $key }}" {{ (Preferences::get('operating-system') == $key || old('operating-system') == $key) ? 'selected' : '' }}>@lang('operatingsystems.' . $key)</option>
                         @endforeach
                     </select>
-                    
+
                     @if ($errors->has('operating-system'))
                         <p class="text-red-500 text-xs italic mt-2">
                             {{ $errors->first('operating-system') }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::group(['prefix' => '{locale}'], function () {
         Route::get('preferences', 'PreferenceController@index')->name('user.preferences.index');
     });
 
-    Route::post('preferences', 'PreferenceController@store')->name('user.preferences.store');
+    Route::patch('preferences', 'PreferenceController@store')->name('user.preferences.update');
 
     Auth::routes();
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,7 +22,7 @@ Route::group(['prefix' => '{locale}'], function () {
         Route::get('preferences', 'PreferenceController@index')->name('user.preferences.index');
     });
 
-    Route::patch('preferences', 'PreferenceController@store')->name('user.preferences.update');
+    Route::patch('preferences', 'PreferenceController@update')->name('user.preferences.update');
 
     Auth::routes();
 });

--- a/tests/Feature/PreferenceRoutesTest.php
+++ b/tests/Feature/PreferenceRoutesTest.php
@@ -15,7 +15,7 @@ class PreferenceRoutesTest extends TestCase
     function resource_language_can_be_changed()
     {
         $this->be(factory(User::class)->create());
-        $response = $this->post(route_wlocale('user.preferences.store'), [
+        $response = $this->patch(route_wlocale('user.preferences.update'), [
             'resource-language' => 'local-and-english',
             'locale' => 'en',
             'operating-system' => 'macos',
@@ -28,7 +28,7 @@ class PreferenceRoutesTest extends TestCase
     function locale_can_be_changed()
     {
         $this->be(factory(User::class)->create());
-        $response = $this->post(route_wlocale('user.preferences.store'), [
+        $response = $this->patch(route_wlocale('user.preferences.update'), [
             'locale' => 'es',
             'resource-language' => 'local-and-english',
             'operating-system' => 'macos',
@@ -41,7 +41,7 @@ class PreferenceRoutesTest extends TestCase
     function operating_system_can_be_changed()
     {
         $this->be(factory(User::class)->create());
-        $response = $this->post(route_wlocale('user.preferences.store'), [
+        $response = $this->patch(route_wlocale('user.preferences.update'), [
             'operating-system' => 'linux',
             'locale' => 'es',
             'resource-language' => 'local-and-english',

--- a/tests/Feature/PreferencesPageTest.php
+++ b/tests/Feature/PreferencesPageTest.php
@@ -27,7 +27,7 @@ class PreferencesPageTest extends TestCase
         $this->be(factory(User::class)->create());
 
         $this->get('/en'); // Set locale
-        $this->post(route_wlocale('user.preferences.store'), [
+        $this->patch(route_wlocale('user.preferences.update'), [
             'locale' => 'en',
             'operating-system' => 'macos',
             'resource-language' => 'english',
@@ -35,7 +35,7 @@ class PreferencesPageTest extends TestCase
 
         $this->assertEquals('macos', Preferences::get('operating-system'));
 
-        $response = $this->post(route_wlocale('user.preferences.store'), [
+        $response = $this->patch(route_wlocale('user.preferences.update'), [
             'locale' => 'en',
             'operating-system' => 'windows',
             'resource-language' => 'english',


### PR DESCRIPTION
This fixes #154 - 422 error when switching language preference.

Since preferences can be updated from multiple places and the controller method to update them required all preferences to be present in the POST request, 422 was returned when updating via the resource language preference switcher (only one preference sent).

Renamed the route and controller method and changed the route method to patch.  Updated the preference form and preference-related tests and tried to make the controller method more accommodating should additional preferences be required in the future.

Any feedback is welcome!