### PR TITLE
Update relationship between Modules and Resources so that Resources can be assigned to more than one Module

### DIFF
--- a/app/Module.php
+++ b/app/Module.php
@@ -24,7 +24,7 @@ class Module extends Model implements Completable
 
     public function resources()
     {
-        return $this->hasMany(Resource::class);
+        return $this->belongsToMany(Resource::class)->withTimestamps();
     }
 
     public function suggestedResources()

--- a/app/Nova/Module.php
+++ b/app/Nova/Module.php
@@ -4,7 +4,6 @@ namespace App\Nova;
 
 use Illuminate\Http\Request;
 use Laravel\Nova\Fields\BelongsToMany;
-use Laravel\Nova\Fields\HasMany;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Text;
 use MrMonat\Translatable\Translatable;
@@ -58,7 +57,7 @@ class Module extends BaseResource
             BelongsToMany::make('Tracks')
                 ->hideFromDetail($request->user()->role !== 'admin'),
 
-            HasMany::make('Resources'),
+            BelongsToMany::make('Resources'),
         ];
     }
 

--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -6,6 +6,7 @@ use App\Facades\Localization;
 use App\Resource as EloquentResource;
 use Illuminate\Http\Request;
 use Inspheric\Fields\Url;
+use Laravel\Nova\Fields\Badge;
 use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\Boolean;
@@ -71,9 +72,15 @@ class Resource extends BaseResource
                 ->options(array_merge(['all' => 'All (contains multiple translations)'], Localization::all()))
                 ->rules('required'),
 
-            Boolean::make('Is Free'),
+            Boolean::make('Is Free')
+                ->hideFromIndex(),
 
-            Boolean::make('Is Bonus'),
+            Boolean::make('Is Bonus')
+                ->hideFromIndex(),
+
+            Boolean::make('Is Assigned To Module', function () {
+                return $this->isAssignedToAModule();
+            }),
 
             BelongsToMany::make('Modules'),
         ];

--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -6,8 +6,6 @@ use App\Facades\Localization;
 use App\Resource as EloquentResource;
 use Illuminate\Http\Request;
 use Inspheric\Fields\Url;
-use Laravel\Nova\Fields\Badge;
-use Laravel\Nova\Fields\BelongsTo;
 use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\ID;

--- a/app/Nova/Resource.php
+++ b/app/Nova/Resource.php
@@ -7,6 +7,7 @@ use App\Resource as EloquentResource;
 use Illuminate\Http\Request;
 use Inspheric\Fields\Url;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\BelongsToMany;
 use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
@@ -74,7 +75,7 @@ class Resource extends BaseResource
 
             Boolean::make('Is Bonus'),
 
-            BelongsTo::make('Module'),
+            BelongsToMany::make('Modules'),
         ];
     }
 

--- a/app/Resource.php
+++ b/app/Resource.php
@@ -79,4 +79,9 @@ class Resource extends Model implements Completable
 
         $query->whereIn('os', [OperatingSystem::ANY, Preferences::get('operating-system')]);
     }
+
+    public function isAssignedToAModule()
+    {
+        return collect($this->modules)->isNotEmpty();
+    }
 }

--- a/app/Resource.php
+++ b/app/Resource.php
@@ -30,9 +30,9 @@ class Resource extends Model implements Completable
         'is_free' => 'boolean',
     ];
 
-    public function module()
+    public function modules()
     {
-        return $this->belongsTo(Module::class);
+        return $this->belongsToMany(Module::class)->withTimestamps();
     }
 
     public function completions()

--- a/database/migrations/2020_03_20_183815_create_module_resource_table.php
+++ b/database/migrations/2020_03_20_183815_create_module_resource_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateModuleResourceTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('module_resource', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('module_id');
+            $table->unsignedBigInteger('resource_id');
+            $table->timestamps();
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('module_resource');
+    }
+}

--- a/database/migrations/2020_03_20_190416_update_module_id_column_on_resource_table.php
+++ b/database/migrations/2020_03_20_190416_update_module_id_column_on_resource_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateModuleIdColumnOnResourceTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->unsignedBigInteger('module_id')->nullable()->change();
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('resources', function (Blueprint $table) {
+            $table->unsignedBigInteger('module_id')->change();
+        });
+    }
+}

--- a/resources/views/glossary.blade.php
+++ b/resources/views/glossary.blade.php
@@ -27,7 +27,9 @@
                             <span class="text-gray-800">Related resources:</span>
                             @foreach ($term->resourcesForCurrentSession()->get() as $resource)
                                 <span>
-                                    <a href="{{ route_wlocale('modules.show', $resource->module()->first()) }}">{{ $resource->module()->first()->name }}</a>
+                                    {{-- @todo update this to either show first module, all modules, or none if resource unassigned --}}
+
+                                    {{-- <a href="{{ route_wlocale('modules.show', $resource->module()->first()) }}">{{ $resource->module()->first()->name }}</a> --}}
                                     &gt;
                                     <a href="{{ $resource->url }}">{{ $resource->name }} <img src="/images/outbound_link_icon.svg" alt="Outbound link" class="w-4 inline align-text-top"></a>
                                 </span>

--- a/tests/Feature/SuggestedResourcesTest.php
+++ b/tests/Feature/SuggestedResourcesTest.php
@@ -13,7 +13,7 @@ use Tests\TestCase;
 
 class SuggestedResourcesTest extends TestCase
 {
-   use RefreshDatabase, WithFaker;
+    use RefreshDatabase, WithFaker;
 
     /** @test */
     function rejected_reason_field_shows_when_a_resource_has_been_rejected()


### PR DESCRIPTION
When we're ready to deploy this PR to production we'll have to do a few things:

- run new migrations
- manually create a new many-to-many relationship between existing resources and modules by running the following:
``` php
Resource::each(function ($resource) {
    $resource->modules()->attach($resource->module_id);
});
```


After this is done and all is well in production, we can create a new migration to remove the `module_id` column from the resources table.

This resolves #185. Also once this is in production #178 can be completed.