### PR TITLE
Update Git Ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Homestead.yaml
 npm-debug.log
 yarn-error.log
 auth.json
+public/mix-manifest.json

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,5 +1,0 @@
-{
-    "/js/app.js": "/js/app.js",
-    "/css/app.css": "/css/app.css",
-    "/js/scripts.js": "/js/scripts.js"
-}


### PR DESCRIPTION
This will not push the mix manifest to github. Reason for this is that any developers that run this project locally and update the FE will cause merge conflicts