### PR TITLE
Fix issue on Module listing mobile view  when scrolling after selecting a tab

### DIFF
--- a/resources/js/components/Tabs/Tabs.vue
+++ b/resources/js/components/Tabs/Tabs.vue
@@ -42,6 +42,7 @@ export default {
     data() {
         return {
             tabs: [],
+            windowWidth: window.innerWidth,
         }
     },
 
@@ -84,11 +85,17 @@ export default {
                 return;
             }
 
+            if(this.windowWidth === window.innerWidth) {
+                return;
+            }
+
             if (window.innerWidth >= 992) {
                 this.showAllTabs();
             } else {
                 this.setActiveTab(this.tabs[0].href);
             }
+
+            this.windowWidth = window.innerWidth;
         },
     },
 }


### PR DESCRIPTION
Resolves #245.

This issue was being cause by the window resize event that happens on mobile devices when you scroll. A change in the window height is detected. The code has been updated to only account for changes in the window width.