### PR TITLE
Close language and user menus when clicking outside

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -8,6 +8,7 @@ require('./bootstrap');
 
 window.Vue = require('vue');
 import './components';
+import ClickOutside from './directives/ClickOutside';
 import Lang from 'lang.js';
 import Notifications from 'vue-notification';
 import Translations from './translations';
@@ -35,6 +36,8 @@ Vue.filter('slug', function (string) {
         .replace(/\s+/g, '-')
         .replace(/-+/g, '-');
 });
+
+Vue.directive('click-outside', ClickOutside);
 
 const app = new Vue({
     el: '#app',

--- a/resources/js/components/Menu/MenuDropdown.vue
+++ b/resources/js/components/Menu/MenuDropdown.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="relative inline-block text-left">
+    <div class="relative inline-block text-left" v-click-outside="close">
         <div>
             <slot name="toggle" :toggle="toggle">
                 <span class="text-blue-violet">

--- a/resources/js/directives/ClickOutside.js
+++ b/resources/js/directives/ClickOutside.js
@@ -1,0 +1,17 @@
+export default {
+    bind(el, binding, vnode) {
+        const listener = e => {
+            if (e.target === el || el.contains(e.target)) {
+                return;
+            }
+
+            binding.value();
+        };
+
+        document.addEventListener('click', listener);
+
+        vnode.context.$once('hook:beforeDestroy', () => {
+            document.removeEventListener('click', listener)
+        });
+    },
+}


### PR DESCRIPTION
This PR addresses #221 by applying a `v-click-outside` to the `menu-dropdown` component.  The result is that when clicking outside of either an opened language menu or user menu, the menu will close.  

In addition, the language and user menus can no longer be opened at the same time since clicking to open one will close the other.

![click-outside](https://user-images.githubusercontent.com/1121383/88720621-c5f03580-d0ea-11ea-9412-f1110d5415e0.gif)

