### PR TITLE
Allow users to update their information via Profile page

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Http\Controllers;
+
+class ProfileController extends Controller
+{
+    public function show()
+    {
+        return view('profile');
+    }
+
+    public function update()
+    {
+        $validated = request()->validate([
+            'name' => 'required',
+            'email' => 'required|email',
+        ]);
+
+        auth()->user()->update($validated);
+
+        return redirect(route_wlocale('user.profile.show'));
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -99,6 +99,11 @@ class User extends Authenticatable
         return explode(' ', $this->name)[0];
     }
 
+    public function getProfilePictureAttribute()
+    {
+        return 'https://www.gravatar.com/avatar/' . md5(strtolower($this->email)) . '?d=mp';
+    }
+
     public function sendPasswordResetNotification($token)
     {
         $this->notify(new ResetPassword($token));

--- a/resources/views/components/button/primary.blade.php
+++ b/resources/views/components/button/primary.blade.php
@@ -1,0 +1,12 @@
+@props([
+    'type' => 'submit',
+])
+
+<span class="inline-flex rounded-md shadow-sm">
+    <button
+        type="{{ $type }}"
+        class="py-2 lg:text-lg button button-purple"
+    >
+        {{ $slot }}
+    </button>
+</span>

--- a/resources/views/components/form/heading.blade.php
+++ b/resources/views/components/form/heading.blade.php
@@ -1,0 +1,5 @@
+<div class="pb-5 mt-12 border-b border-gray-300">
+    <h2 class="text-xl font-medium md:text-2xl lg:text-3xl">
+        {{ $slot }}
+    </h2>
+</div>

--- a/resources/views/components/form/section.blade.php
+++ b/resources/views/components/form/section.blade.php
@@ -1,0 +1,11 @@
+<div class="mt-5">
+    @isset($description)
+        <p class="text-sm leading-5 text-gray-700 md:text-base">
+            {{ $description }}
+        </p>
+    @endisset
+
+    <div class="flex flex-wrap px-5 pb-2 mt-6 border border-gray-300 lg:flex-no-wrap md:px-8">
+        {{ $slot }}
+    </div>
+</div>

--- a/resources/views/components/input/text.blade.php
+++ b/resources/views/components/input/text.blade.php
@@ -1,0 +1,32 @@
+@props([
+    'name',
+    'label',
+    'value' => null,
+    'type' => 'text',
+])
+
+<div class="flex-auto w-full my-5 lg:flex-even md:my-8">
+    <label
+        for="{{ $name }}"
+        id="{{ $name }}-label"
+        class="text-base font-medium text-gray-900"
+    >
+        {{ $label }}
+    </label>
+
+    <div class="relative max-w-xs mt-4">
+        <input
+            type="{{ $type }}"
+            class="block w-full px-4 py-2 text-sm pr-8 leading-tight bg-white border border-gray-400 rounded shadow appearance-none hover:border-gray-500 focus:outline-none focus:shadow-outline{{ $errors->has($name) ? ' border-red-500' : '' }}"
+            name="{{ $name }}"
+            aria-labelledby="{{ $name }}-label"
+            value="{{ old($name, $value) }}"
+        >
+    </div>
+
+    @error($name)
+        <p class="mt-2 text-xs italic text-red-500">
+            {{ $errors->first($name) }}
+        </p>
+    @enderror
+</div>

--- a/resources/views/partials/navigation/header.blade.php
+++ b/resources/views/partials/navigation/header.blade.php
@@ -11,7 +11,7 @@
                 <img class="w-auto h-5 md:h-8" src="/images/logo/onramp.svg" alt="Onramp">
             </a>
 
-            <button 
+            <button
                 class="focus:outline-none lg:hidden"
                 aria-label="open menu"
                 @click="openModal('mobileMenu')"
@@ -71,6 +71,11 @@
                                     </span>
                                 </button>
                             </template>
+
+                            <menu-dropdown-item
+                                text="{{ __('Profile') }}"
+                                href="{{ route_wlocale('user.profile.show') }}">
+                            </menu-dropdown-item>
 
                             <menu-dropdown-item
                                 text="{{ __('Preferences') }}"

--- a/resources/views/partials/navigation/header.blade.php
+++ b/resources/views/partials/navigation/header.blade.php
@@ -63,12 +63,10 @@
                         <menu-dropdown>
                             <template v-slot:toggle="props">
                                 <button
-                                    class="flex items-center justify-center block w-12 h-12 transition-colors duration-300 ease-in-out bg-teal-700 rounded-full hover:bg-teal-600 hover:no-underline focus:outline-none"
+                                    class="flex items-center justify-center block w-12 h-12 hover:no-underline focus:outline-none"
                                     @click="props.toggle"
                                 >
-                                    <span class="font-semibold leading-none text-white">
-                                        {{ Auth::user()->initials }}
-                                    </span>
+                                    <img class="rounded-full" src="{{ auth()->user()->profile_picture }}" alt="{{ auth()->user()->name }}">
                                 </button>
                             </template>
 

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -1,0 +1,45 @@
+@extends('layouts.app')
+
+@section('content')
+
+<div class="w-full bg-white">
+    <div class="py-16 overflow-hidden bg-indigo-100 lg:py-24">
+        <div class="fluid-container">
+            <h1 class="max-w-lg">{{ __('My Profile') }}</h1>
+        </div>
+    </div>
+
+    <div class="pb-48 fluid-container lg:pt-8">
+        <form method="post" action="{{ route_wlocale('user.profile.update') }}">
+            @method('PUT')
+            @csrf
+
+            <x-form.heading>{{ __('Account Settings') }}</x-form.heading>
+
+            <x-form.section>
+                <x-input.text
+                    name="name"
+                    :label="__('Name')"
+                    :value="auth()->user()->name"
+                ></x-input.text>
+
+                <x-input.text
+                    name="email"
+                    :label="__('Email')"
+                    :value="auth()->user()->email"
+                    type="email"
+                ></x-input.text>
+            </x-form.section>
+
+            <div class="pt-5 mt-8">
+                <div class="flex justify-start">
+                    <x-button.primary>
+                        {{ ucfirst(__('save')) }}
+                    </x-button.primary>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>
+
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,8 @@ Route::group(['prefix' => '{locale}'], function () {
     Route::group(['middleware' => 'auth'], function () {
         Route::get('wizard', 'Auth\\WizardController@index')->name('wizard.index');
         Route::post('wizard', 'Auth\\WizardController@store')->name('wizard.store');
+        Route::get('profile', 'ProfileController@show')->name('user.profile.show');
+        Route::put('profile', 'ProfileController@update')->name('user.profile.update');
         Route::get('preferences', 'PreferenceController@index')->name('user.preferences.index');
         Route::post('completions', 'CompletionsController@store')->name('user.completions.store');
         Route::delete('completions', 'CompletionsController@destroy')->name('user.completions.destroy');

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProfileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function users_can_access_their_profile_page()
+    {
+        $user = factory(User::class)->create();
+
+        $this->be($user)->get(route_wlocale('user.profile.show'))
+            ->assertStatus(200);
+    }
+
+    /** @test */
+    function users_can_update_their_profile_settings()
+    {
+        $user = factory(User::class)->create([
+            'name' => 'Caleb Dume',
+            'email' => 'test@example.com',
+        ]);
+
+        $response = $this->be($user)->put(route_wlocale('user.profile.update'), [
+            'name' => 'Kanan Jarrus',
+            'email' => 'updated@example.com',
+        ]);
+
+        tap($user->fresh(), function ($user) {
+            $this->assertEquals('Kanan Jarrus', $user->name);
+            $this->assertEquals('updated@example.com', $user->email);
+        });
+
+        $response->assertRedirect(route_wlocale('user.profile.show'));
+    }
+
+    /** @test */
+    function only_authenticated_users_can_update_their_profile()
+    {
+        $response = $this->put(route_wlocale('user.profile.update'));
+
+        $response->assertRedirect(route_wlocale('login'));
+    }
+
+    /** @test */
+    function updating_user_profile_requires_a_name_and_email()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->be($user)->put(route_wlocale('user.profile.update'));
+
+        $response->assertSessionHasErrors('name');
+        $response->assertSessionHasErrors('email');
+    }
+
+    /** @test */
+    function updating_user_profile_requires_a_valid_email()
+    {
+        $user = factory(User::class)->create();
+
+        $response = $this->be($user)->put(route_wlocale('user.profile.update'), [
+            'email' => 'invalid',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+    }
+}


### PR DESCRIPTION
This PR addresses #220 by:

1. allowing users to update their name and email address via a new profile page (`/profile`)
1. uses [Gravatar](https://en.gravatar.com/) for displaying user profile images. With @mattstauffer's blessing, we're going to hold off on allowing users to upload their own images since the site does not currently have public facing profiles.

The following blade components were extracted in the process:
1. `<x-button.primary>`: button that defaults to the type of `submit`
1. `<x-form.heading>`: displays `Account Settings` in the screenshot below
1. `<x-form.section>`: wraps a section of a form with a border. Can optionally pass in a description
1. `<x-input.text>`: simple text input

---

### Profile Page
|||
|:-:|:-:|
|Menu|![image](https://user-images.githubusercontent.com/1141514/88861238-69584d80-d1b2-11ea-9c3a-f92dca82c03f.png)|
|Page|![image](https://user-images.githubusercontent.com/1141514/88861305-8bea6680-d1b2-11ea-9b1d-01bae40b4bab.png)|

### Gravatar Images
|||
|:-:|:-:|
|Gravatar **has** image for user|![image](https://user-images.githubusercontent.com/1141514/88860590-f9959300-d1b0-11ea-86a7-838f9e093970.png)|
|Gravatar **does not have** image for user|![image](https://user-images.githubusercontent.com/1141514/88860596-fc908380-d1b0-11ea-8e5f-eda932909dd6.png)|

### Components
|||
|:-:|:-:|
|Form section with `<x-slot name="description"></x-slot>` provided|![image](https://user-images.githubusercontent.com/1141514/88861829-abce5a00-d1b3-11ea-80db-9370bc99ec19.png)|


---

Closes #220 