### PR TITLE
Add an active state for desktop nav items

### DIFF
--- a/resources/views/partials/navigation/header.blade.php
+++ b/resources/views/partials/navigation/header.blade.php
@@ -30,13 +30,13 @@
             <div class="flex-1">
                 <nav class="flex items-center">
                     <a
-                        class="block mx-4 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-indigo-800 hover:no-underline"
+                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-indigo-800 hover:no-underline px-3 py-1 rounded @if(Route::currentRouteName() === 'modules.index') bg-indigo-100 @endif"
                         href="{{ route_wlocale('modules.index') }}">
                         <span>Learn</span>
                     </a>
 
                     <a
-                        class="block mx-4 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-indigo-800 hover:no-underline"
+                        class="block mx-1 text-xl font-semibold transition-colors duration-300 ease-in-out text-blue-violet hover:text-indigo-800 hover:no-underline px-3 py-1 rounded @if(Route::currentRouteName() === 'glossary') bg-indigo-100 @endif"
                         href="{{ route_wlocale('glossary')}}">
                         <span>Glossary</span>
                     </a>


### PR DESCRIPTION
This PR addresses #222 by adding an active state to the `Learn` and `Glossary` nav items in desktop mode.

![image](https://user-images.githubusercontent.com/1121383/88965551-8a7f7380-d270-11ea-86ea-b9a2d33fd2b8.png)

![image](https://user-images.githubusercontent.com/1121383/88965597-9b2fe980-d270-11ea-818b-22f1ec0b925a.png)