### PR TITLE
Add is free field to Suggested Resources

### DIFF
--- a/app/Nova/Actions/ApproveSuggestedResource.php
+++ b/app/Nova/Actions/ApproveSuggestedResource.php
@@ -34,6 +34,7 @@ class ApproveSuggestedResource extends Action
                 'type' => $model->type,
                 'module_id' => $model->module_id,
                 'language' => $model->language,
+                'is_free' => $model->is_free,
             ]);
 
             $resource->modules()->attach($model->module_id);

--- a/app/Nova/SuggestedResource.php
+++ b/app/Nova/SuggestedResource.php
@@ -12,6 +12,7 @@ use Illuminate\Http\Request;
 use Inspheric\Fields\Url;
 use Laravel\Nova\Fields\Badge;
 use Laravel\Nova\Fields\BelongsTo;
+use Laravel\Nova\Fields\Boolean;
 use Laravel\Nova\Fields\ID;
 use Laravel\Nova\Fields\Select;
 use Laravel\Nova\Fields\Text;
@@ -86,6 +87,9 @@ class SuggestedResource extends BaseResource
                 ->options($this->typeFields())
                 ->displayUsingLabels()
                 ->rules('required'),
+
+            Boolean::make('Is Free')
+                ->hideFromIndex(),
 
             Textarea::make('Notes'),
         ];

--- a/database/factories/SuggestedResourceFactory.php
+++ b/database/factories/SuggestedResourceFactory.php
@@ -8,5 +8,6 @@ $factory->define(SuggestedResource::class, function (Faker $faker) {
         'name' => $faker->sentence,
         'url' => $faker->url,
         'language' => $faker->randomElement(array_merge(['all'], Localization::slugs())),
+        'is_free' => $faker->boolean,
     ];
 });

--- a/database/migrations/2020_07_31_210902_add_is_free_column_to_suggested_resources_table.php
+++ b/database/migrations/2020_07_31_210902_add_is_free_column_to_suggested_resources_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIsFreeColumnToSuggestedResourcesTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('suggested_resources', function (Blueprint $table) {
+            $table->boolean('is_free')->default(true);
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('suggested_resources', function (Blueprint $table) {
+            $table->dropColumn('is_free');
+        });
+    }
+}


### PR DESCRIPTION
This PR adds an `is_free` field to Suggested Resources and applies the field to Resources when they are created via the Approve Resource action in Nova.