### PR TITLE
Enable PurgeCSS

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,10 @@
 module.exports = {
+    purge: [
+        './**/*.html',
+        './**/*.vue',
+        './**/*.js',
+        './**/*.blade.php',
+    ],
     theme: {
         extend: {
             colors: {


### PR DESCRIPTION
This PR enables [Tailwind's PurgeCSS integration](https://tailwindcss.com/docs/controlling-file-size#purge-css-options). It scans all HTML, Vue, JavaScript, and Blade files in Onramp and purges any Tailwind classes _not_ used in the app from the production CSS output.

This reduces the production CSS output size considerably and should help mitigate #260.

I built it locally before and after this change and clicked around a bit and couldn't see any difference visually, but someone more familiar with Onramp should do a more thorough inspection before merging this.

`npm run prod` before (**4.45MB**):

<img width="525" alt="Screen Shot 2020-08-25 at 11 11 58 AM" src="https://user-images.githubusercontent.com/18192441/91192377-da145c00-e6c3-11ea-84f1-154e5bc33854.png">

`npm run prod` after (**40.5KB**):

<img width="525" alt="Screen Shot 2020-08-25 at 11 03 53 AM" src="https://user-images.githubusercontent.com/18192441/91192016-75590180-e6c3-11ea-9f58-6b8a2a5291d8.png">

**Note:**

1. This only purges Tailwind's classes, so it's safe to use with Onramp's custom CSS (it'll just ignore it).
2. It _will_ purge any classes that are generated/concatenated at runtime (because the complete class name doesn't appear in the source), so it's important to [write purgeable HTML](https://tailwindcss.com/docs/controlling-file-size#writing-purgeable-html). I'm not super familiar with Onramp and I did **not** check to see if we're doing that anywhere.